### PR TITLE
feat: add authorizedSigners to operators

### DIFF
--- a/contracts/src/contracts/EigenLayerMiddlewareV4.sol
+++ b/contracts/src/contracts/EigenLayerMiddlewareV4.sol
@@ -186,6 +186,14 @@ contract EigenLayerMiddlewareV4 is OwnableUpgradeable, UUPSUpgradeable, IAVSRegi
         return activeStake;
     }
 
+    /// @notice Unpause an operator
+    /// @dev This function is used to unpause an operator that has been paused
+    function unpauseOperator() public {
+        address operator = msg.sender;
+
+        OPERATORS_REGISTRY.unpauseOperator(operator);
+    }
+
     // ========= Strategy queries ========= //
 
     /// @notice Get all whitelisted strategies for this AVS, including inactive ones.

--- a/contracts/src/contracts/EigenLayerMiddlewareV4.sol
+++ b/contracts/src/contracts/EigenLayerMiddlewareV4.sol
@@ -131,14 +131,6 @@ contract EigenLayerMiddlewareV4 is OwnableUpgradeable, UUPSUpgradeable, IAVSRegi
 
     // ========= AVS functions ========= //
 
-    /// @notice Update the RPC endpoint of the operator
-    /// @param rpcEndpoint The new RPC endpoint
-    function updateOperatorRpcEndpoint(
-        string calldata rpcEndpoint
-    ) public {
-        OPERATORS_REGISTRY.updateOperatorRpcEndpoint(msg.sender, rpcEndpoint);
-    }
-
     /// @notice Get the collaterals and amounts staked by an operator across the whitelisted strategies
     /// @param operator The operator address to get the collaterals and amounts staked for
     /// @return collaterals The collaterals staked by the operator
@@ -194,6 +186,8 @@ contract EigenLayerMiddlewareV4 is OwnableUpgradeable, UUPSUpgradeable, IAVSRegi
         return activeStake;
     }
 
+    // ========= Strategy queries ========= //
+
     /// @notice Get all whitelisted strategies for this AVS, including inactive ones.
     /// @return The list of whitelisted strategies
     function getWhitelistedStrategies() public view returns (address[] memory) {
@@ -233,7 +227,6 @@ contract EigenLayerMiddlewareV4 is OwnableUpgradeable, UUPSUpgradeable, IAVSRegi
     /// @notice Register an operator through the AVS Directory
     /// @param rpcEndpoint The RPC URL of the operator
     /// @param extraData Arbitrary data the operator can provide as part of registration
-    /// @param operator The address of the operator being registered
     /// @param operatorSignature The signature of the operator
     /// @param authorizedSigners The addresses authorized to sign commitment on behalf of the operator.
     /// @dev This function is used before the ELIP-002 (slashing) EigenLayer upgrade to register operators.
@@ -241,10 +234,11 @@ contract EigenLayerMiddlewareV4 is OwnableUpgradeable, UUPSUpgradeable, IAVSRegi
     function registerOperatorToAVS(
         string memory rpcEndpoint,
         string memory extraData,
-        address operator,
         ISignatureUtils.SignatureWithSaltAndExpiry calldata operatorSignature,
         address[] memory authorizedSigners
     ) public {
+        address operator = msg.sender;
+
         require(DELEGATION_MANAGER.isOperator(operator), NotOperator());
 
         // The operator signature is checked in the AVS Directory contract
@@ -253,12 +247,11 @@ contract EigenLayerMiddlewareV4 is OwnableUpgradeable, UUPSUpgradeable, IAVSRegi
     }
 
     /// @notice Deregister an operator through the AVS Directory
-    /// @param operator The address of the operator being deregistered
     /// @dev This function is used before the ELIP-002 (slashing) EigenLayer upgrade to deregister operators.
     /// @dev Operators must use this function to deregister before the upgrade. After the upgrade, this will be removed.
-    function deregisterOperatorFromAVS(
-        address operator
-    ) public {
+    function deregisterOperatorFromAVS() public {
+        address operator = msg.sender;
+
         require(DELEGATION_MANAGER.isOperator(operator), NotOperator());
 
         AVS_DIRECTORY.deregisterOperatorFromAVS(operator);

--- a/contracts/src/contracts/EigenLayerMiddlewareV4.sol
+++ b/contracts/src/contracts/EigenLayerMiddlewareV4.sol
@@ -1,0 +1,536 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.27;
+
+import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+import {UUPSUpgradeable} from "@openzeppelin-v5.0.0/contracts/proxy/utils/UUPSUpgradeable.sol";
+import {Time} from "@openzeppelin-v5.0.0/contracts/utils/types/Time.sol";
+
+import {PauseableEnumerableSet} from "@symbiotic/middleware-sdk/libraries/PauseableEnumerableSet.sol";
+
+import {
+    IAllocationManager, IAllocationManagerTypes
+} from "@eigenlayer/src/contracts/interfaces/IAllocationManager.sol";
+import {ISignatureUtils} from "@eigenlayer/src/contracts/interfaces/ISignatureUtils.sol";
+import {IDelegationManager} from "@eigenlayer/src/contracts/interfaces/IDelegationManager.sol";
+import {IStrategyManager} from "@eigenlayer/src/contracts/interfaces/IStrategyManager.sol";
+import {IAVSDirectory} from "@eigenlayer/src/contracts/interfaces/IAVSDirectory.sol";
+import {IAVSRegistrar} from "@eigenlayer/src/contracts/interfaces/IAVSRegistrar.sol";
+import {IStrategy} from "@eigenlayer/src/contracts/interfaces/IStrategy.sol";
+
+import {IRestakingMiddlewareV1} from "../interfaces/IRestakingMiddlewareV1.sol";
+import {IOperatorsRegistryV2} from "../interfaces/IOperatorsRegistryV2.sol";
+
+/**
+ * @title BoltEigenLayerMiddlewareV4
+ * @author Chainbound Developers <dev@chainbound.io>
+ * @notice This contract is responsible for interacting with the EigenLayer restaking protocol contracts. It serves
+ *         as AVS contract and implements the IAVSRegistrar interface as well.
+ */
+contract EigenLayerMiddlewareV4 is OwnableUpgradeable, UUPSUpgradeable, IAVSRegistrar, IRestakingMiddlewareV1 {
+    using PauseableEnumerableSet for PauseableEnumerableSet.AddressSet;
+
+    /// @notice Address of the EigenLayer AVS Directory contract.
+    IAVSDirectory public AVS_DIRECTORY;
+
+    /// @notice Address of the EigenLayer Allocation Manager contract.
+    IAllocationManager public ALLOCATION_MANAGER;
+
+    /// @notice Address of the EigenLayer Delegation Manager contract.
+    IDelegationManager public DELEGATION_MANAGER;
+
+    /// @notice Address of the EigenLayer Strategy Manager contract.
+    IStrategyManager public STRATEGY_MANAGER;
+
+    /// @notice Address of the Bolt Operators Registry contract.
+    IOperatorsRegistryV2 public OPERATORS_REGISTRY;
+
+    /// @notice The name of the middleware
+    bytes32 public NAME_HASH;
+
+    /// @notice The list of whitelisted strategies for this AVS
+    PauseableEnumerableSet.AddressSet internal _strategyWhitelist;
+
+    /// @dev This empty reserved space is put in place to allow future versions to add new
+    /// variables without shifting down storage in the inheritance chain.
+    /// See https://docs.openzeppelin.com/contracts/4.x/upgradeable#storage_gaps
+    /// This can be validated with the Openzeppelin Foundry Upgrades toolkit.
+    ///
+    /// Total storage slots: 50
+    uint256[42] private __gap;
+
+    // ========= Events ========= //
+
+    /// @notice Emitted when a strategy is whitelisted
+    event StrategyWhitelisted(address indexed strategy);
+
+    /// @notice Emitted when a strategy is removed from the whitelist
+    event StrategyRemoved(address indexed strategy);
+
+    /// @notice Emitted when a strategy is paused
+    event StrategyPaused(address indexed strategy);
+
+    /// @notice Emitted when a strategy is unpaused
+    event StrategyUnpaused(address indexed strategy);
+
+    // ========= Errors ========= //
+
+    error NotOperator();
+    error UnauthorizedStrategy();
+    error NotAllocationManager();
+    error InvalidStrategyAddress();
+    error StrategyAlreadyWhitelisted();
+
+    // ========= Initializer & Proxy functionality ========= //
+
+    /// @notice Initialize the contract
+    /// @param owner The address of the owner
+    /// @param _avsDirectory The address of the EigenLayer AVS Directory contract
+    /// @param _eigenlayerAllocationManager The address of the EigenLayer Allocation Manager contract
+    /// @param _eigenlayerDelegationManager The address of the EigenLayer Delegation Manager contract
+    /// @param _eigenlayerStrategyManager The address of the EigenLayer Strategy Manager contract
+    /// @param _operatorsRegistry The address of the Operators Registry contract
+    function initialize(
+        address owner,
+        IOperatorsRegistryV2 _operatorsRegistry,
+        IAVSDirectory _avsDirectory,
+        IAllocationManager _eigenlayerAllocationManager,
+        IDelegationManager _eigenlayerDelegationManager,
+        IStrategyManager _eigenlayerStrategyManager
+    ) public initializer {
+        __Ownable_init(owner);
+
+        AVS_DIRECTORY = _avsDirectory;
+        ALLOCATION_MANAGER = _eigenlayerAllocationManager;
+        DELEGATION_MANAGER = _eigenlayerDelegationManager;
+        STRATEGY_MANAGER = _eigenlayerStrategyManager;
+        OPERATORS_REGISTRY = _operatorsRegistry;
+        NAME_HASH = keccak256("EIGENLAYER");
+    }
+
+    /// @notice Re-Initialize the contract after the upgrade
+    /// @param owner The address of the owner
+    function initializeV4(
+        address owner
+    ) public reinitializer(4) {
+        __Ownable_init(owner);
+    }
+
+    /// @notice Upgrade the contract
+    /// @param newImplementation The address of the new implementation
+    function _authorizeUpgrade(
+        address newImplementation
+    ) internal override onlyOwner {}
+
+    // ========= Modifiers ========= //
+
+    /// @notice Modifier to check if the caller is the AllocationManager
+    modifier onlyAllocationManager() {
+        require(msg.sender == address(ALLOCATION_MANAGER), NotAllocationManager());
+        _;
+    }
+
+    // ========= AVS functions ========= //
+
+    /// @notice Update the RPC endpoint of the operator
+    /// @param rpcEndpoint The new RPC endpoint
+    function updateOperatorRpcEndpoint(
+        string calldata rpcEndpoint
+    ) public {
+        OPERATORS_REGISTRY.updateOperatorRpcEndpoint(msg.sender, rpcEndpoint);
+    }
+
+    /// @notice Get the collaterals and amounts staked by an operator across the whitelisted strategies
+    /// @param operator The operator address to get the collaterals and amounts staked for
+    /// @return collaterals The collaterals staked by the operator
+    /// @dev Assumes that the operator is registered and enabled
+    function getOperatorCollaterals(
+        address operator
+    ) public view returns (address[] memory, uint256[] memory) {
+        // Only take strategies that are active at <timestamp>
+        IStrategy[] memory activeStrategies = _getActiveStrategiesAt(_now());
+
+        address[] memory collateralTokens = new address[](activeStrategies.length);
+        uint256[] memory amounts = new uint256[](activeStrategies.length);
+
+        // get the shares of the operator across all strategies
+        uint256[] memory shares = DELEGATION_MANAGER.getOperatorShares(operator, activeStrategies);
+
+        // get the collateral tokens and amounts for the operator across all strategies
+        for (uint256 i = 0; i < activeStrategies.length; i++) {
+            collateralTokens[i] = address(activeStrategies[i].underlyingToken());
+            amounts[i] = activeStrategies[i].sharesToUnderlyingView(shares[i]);
+        }
+
+        return (collateralTokens, amounts);
+    }
+
+    /// @notice Get the CURRENT amount staked by an operator for a specific collateral
+    /// @param operator The operator address to get the amount staked for
+    /// @param collateral The collateral token address
+    /// @return The amount staked by the operator for the collateral
+    function getOperatorStake(address operator, address collateral) public view returns (uint256) {
+        uint256 activeStake = 0;
+        for (uint256 i = 0; i < _strategyWhitelist.length(); i++) {
+            (address strategy, uint48 enabledAt, uint48 disabledAt) = _strategyWhitelist.at(i);
+
+            if (!_wasEnabledAt(enabledAt, disabledAt, _now())) {
+                continue;
+            }
+
+            if (address(IStrategy(strategy).underlyingToken()) != collateral) {
+                continue;
+            }
+
+            // get the shares of the operator for the strategy
+            // NOTE: the EL slashing-magnitudes branch removed the operatorShares(operator, strategy) function:
+            // https://github.com/Layr-Labs/eigenlayer-contracts/blob/dev/src/contracts/interfaces/IDelegationManager.sol#L352-L359
+            // so we need to use getOperatorShares(operator, [strategy]) instead.
+            IStrategy[] memory strategies = new IStrategy[](1);
+            strategies[0] = IStrategy(strategy);
+            uint256[] memory shares = DELEGATION_MANAGER.getOperatorShares(operator, strategies);
+            activeStake += IStrategy(strategy).sharesToUnderlyingView(shares[0]);
+        }
+
+        return activeStake;
+    }
+
+    /// @notice Get all whitelisted strategies for this AVS, including inactive ones.
+    /// @return The list of whitelisted strategies
+    function getWhitelistedStrategies() public view returns (address[] memory) {
+        address[] memory strategies = new address[](_strategyWhitelist.length());
+
+        for (uint256 i = 0; i < _strategyWhitelist.length(); i++) {
+            (strategies[i],,) = _strategyWhitelist.at(i);
+        }
+
+        return strategies;
+    }
+
+    /// @notice Get the active strategies for this AVS
+    /// @return The active strategies
+    function getActiveWhitelistedStrategies() public view returns (IStrategy[] memory) {
+        // Use the beginning of the current epoch to check which strategies were enabled at that time.
+        return _getActiveStrategiesAt(_now());
+    }
+
+    /// @notice Get the number of whitelisted strategies for this AVS.
+    /// @return The number of whitelisted strategies.
+    function strategyWhitelistLength() public view returns (uint256) {
+        return _strategyWhitelist.length();
+    }
+
+    /// @notice Returns whether the strategy is active in this epoch.
+    /// @param strategy The strategy to check.
+    /// @return True if the strategy is active in this epoch, false otherwise.
+    function isStrategyActive(
+        address strategy
+    ) public view returns (bool) {
+        return _strategyWhitelist.wasActiveAt(_now(), strategy);
+    }
+
+    // ========= [pre-ELIP-002] IServiceManager functions ========= //
+
+    /// @notice Register an operator through the AVS Directory
+    /// @param rpcEndpoint The RPC URL of the operator
+    /// @param extraData Arbitrary data the operator can provide as part of registration
+    /// @param operator The address of the operator being registered
+    /// @param operatorSignature The signature of the operator
+    /// @param authorizedSigners The addresses authorized to sign commitment on behalf of the operator.
+    /// @dev This function is used before the ELIP-002 (slashing) EigenLayer upgrade to register operators.
+    /// @dev Operators must use this function to register before the upgrade. After the upgrade, this will be removed.
+    function registerOperatorToAVS(
+        string memory rpcEndpoint,
+        string memory extraData,
+        address operator,
+        ISignatureUtils.SignatureWithSaltAndExpiry calldata operatorSignature,
+        address[] memory authorizedSigners
+    ) public {
+        require(DELEGATION_MANAGER.isOperator(operator), NotOperator());
+
+        // The operator signature is checked in the AVS Directory contract
+        AVS_DIRECTORY.registerOperatorToAVS(operator, operatorSignature);
+        OPERATORS_REGISTRY.registerOperator(operator, rpcEndpoint, extraData, authorizedSigners);
+    }
+
+    /// @notice Deregister an operator through the AVS Directory
+    /// @param operator The address of the operator being deregistered
+    /// @dev This function is used before the ELIP-002 (slashing) EigenLayer upgrade to deregister operators.
+    /// @dev Operators must use this function to deregister before the upgrade. After the upgrade, this will be removed.
+    function deregisterOperatorFromAVS(
+        address operator
+    ) public {
+        require(DELEGATION_MANAGER.isOperator(operator), NotOperator());
+
+        AVS_DIRECTORY.deregisterOperatorFromAVS(operator);
+        OPERATORS_REGISTRY.pauseOperator(operator);
+    }
+
+    /// @notice Update the metadata URI for this AVS
+    /// @param contractName The name of the contract to update the metadata URI for
+    /// @param metadataURI The new metadata URI
+    function updateAVSMetadataURI(string calldata contractName, string calldata metadataURI) public onlyOwner {
+        bytes32 contractNameHash = keccak256(abi.encodePacked(contractName));
+
+        if (contractNameHash == keccak256("ALLOCATION_MANAGER")) {
+            ALLOCATION_MANAGER.updateAVSMetadataURI(address(this), metadataURI);
+        } else if (contractNameHash == keccak256("AVS_DIRECTORY")) {
+            AVS_DIRECTORY.updateAVSMetadataURI(metadataURI);
+        }
+    }
+
+    /// @notice Get the strategies that an operator has restaked in
+    /// @param operator The operator address to get the restaked strategies for
+    /// @return The restaked strategy addresses
+    function getOperatorRestakedStrategies(
+        address operator
+    ) public view returns (address[] memory) {
+        // Only take strategies that are active at <timestamp>
+        IStrategy[] memory activeStrategies = _getActiveStrategiesAt(_now());
+
+        address[] memory restakedStrategies = new address[](activeStrategies.length);
+
+        // get the shares of the operator across all strategies
+        uint256[] memory shares = DELEGATION_MANAGER.getOperatorShares(operator, activeStrategies);
+
+        // get the collateral tokens and amounts for the operator across all strategies
+        uint256 restakedCount = 0;
+        for (uint256 i = 0; i < activeStrategies.length; i++) {
+            if (activeStrategies[i].sharesToUnderlyingView(shares[i]) > 0) {
+                restakedStrategies[restakedCount] = address(activeStrategies[i]);
+                restakedCount++;
+            }
+        }
+
+        address[] memory result = new address[](restakedCount);
+        for (uint256 i = 0; i < restakedCount; i++) {
+            result[i] = restakedStrategies[i];
+        }
+
+        return result;
+    }
+
+    /// @notice Get the strategies that operators can restake in
+    /// @return The restakeable strategy addresses
+    function getRestakeableStrategies() public view returns (address[] memory) {
+        // All operators can use all whitelisted, active strategies.
+        IStrategy[] memory strategies = getActiveWhitelistedStrategies();
+
+        // cast to address[] to match the return type
+        address[] memory result = new address[](strategies.length);
+        for (uint256 i = 0; i < strategies.length; i++) {
+            result[i] = address(strategies[i]);
+        }
+
+        return result;
+    }
+
+    // ========= [post-ELIP-002] IAVSRegistrar functions ========= //
+
+    /// @notice Allows the AllocationManager to hook into the middleware to validate operator registration
+    /// @param operator The address of the operator
+    /// @param operatorSetIds The operator set IDs the operator is registering for
+    /// @param data Arbitrary ABI-encoded data the operator must provide as part of registration
+    function registerOperator(
+        address operator,
+        uint32[] calldata operatorSetIds,
+        bytes calldata data
+    ) external onlyAllocationManager {
+        // NOTE: this function is called by AllocationManager.registerForOperatorSets(),
+        // called by operators when registering to this AVS. If this call reverts,
+        // the registration will be unsuccessful.
+
+        // Split the data into rpcEndpoint, extraData and authorizedSigners from ABI encoding
+        (string memory rpcEndpoint, string memory extraData, address[] memory authorizedSigners) =
+            abi.decode(data, (string, string, address[]));
+
+        // We forward the call to the OperatorsRegistry to register the operator in its storage.
+        OPERATORS_REGISTRY.registerOperator(operator, rpcEndpoint, extraData, authorizedSigners);
+    }
+
+    /// @notice Allows the AllocationManager to hook into the middleware to validate operator deregistration
+    /// @param operator The address of the operator
+    /// @param operatorSetIds The operator set IDs the operator is deregistering from
+    function deregisterOperator(address operator, uint32[] calldata operatorSetIds) external onlyAllocationManager {
+        // NOTE: this function is called by AllocationManager.deregisterFromOperatorSets,
+        // called by operators when deregistering from this AVS.
+        // Failure does nothing here: if this call reverts the deregistration will still go through.
+
+        // We forward the call to the OperatorsRegistry to pause the operator from its storage.
+        // In order to be fully removed, the operator must call OPERATORS_REGISTRY.deregisterOperator()
+        // after waiting for the required delay.
+        OPERATORS_REGISTRY.pauseOperator(operator);
+    }
+
+    // ========= Admin functions ========= //
+
+    /// @notice Add a strategy to the whitelist
+    /// @param strategy The strategy to add
+    function whitelistStrategy(
+        address strategy
+    ) public onlyOwner {
+        require(strategy != address(0), InvalidStrategyAddress());
+        require(!_strategyWhitelist.contains(strategy), StrategyAlreadyWhitelisted());
+        require(STRATEGY_MANAGER.strategyIsWhitelistedForDeposit(IStrategy(strategy)), UnauthorizedStrategy());
+
+        _strategyWhitelist.register(_now(), strategy);
+        emit StrategyWhitelisted(strategy);
+    }
+
+    /// @notice Pause a strategy, preventing its collateral from being active in the AVS
+    /// @param strategy The strategy to pause
+    function pauseStrategy(
+        address strategy
+    ) public onlyOwner {
+        require(_strategyWhitelist.contains(strategy), UnauthorizedStrategy());
+
+        // NOTE: we use _now() - 1 to ensure that the strategy is paused in the current epoch.
+        // If we didn't do this, we would have to wait until the next epoch until the strategy was actually paused.
+        _strategyWhitelist.pause(_now() - 1, strategy);
+        emit StrategyPaused(strategy);
+    }
+
+    /// @notice Unpause a strategy, allowing its collateral to be active in the AVS
+    /// @param strategy The strategy to unpause
+    function unpauseStrategy(
+        address strategy
+    ) public onlyOwner {
+        require(_strategyWhitelist.contains(strategy), UnauthorizedStrategy());
+
+        _strategyWhitelist.unpause(_now(), OPERATORS_REGISTRY.EPOCH_DURATION(), strategy);
+        emit StrategyUnpaused(strategy);
+    }
+
+    /// @notice Remove a strategy from the whitelist
+    /// @param strategy The strategy to remove
+    /// @dev Strategies must be paused for an EPOCH_DURATION before they can be removed
+    function removeStrategy(
+        address strategy
+    ) public onlyOwner {
+        require(_strategyWhitelist.contains(strategy), UnauthorizedStrategy());
+
+        // NOTE: we use _now() - 1 to ensure that the strategy is removed in the current epoch.
+        _strategyWhitelist.unregister(_now() - 1, OPERATORS_REGISTRY.EPOCH_DURATION(), strategy);
+        emit StrategyRemoved(strategy);
+    }
+
+    /// @notice Create new operator sets for this AVS
+    /// @param params The parameters for creating the operator sets
+    function createOperatorSets(
+        IAllocationManagerTypes.CreateSetParams[] calldata params
+    ) public onlyOwner {
+        for (uint256 i = 0; i < params.length; i++) {
+            _checkAreAllStrategiesWhitelisted(params[i].strategies);
+        }
+
+        ALLOCATION_MANAGER.createOperatorSets(address(this), params);
+    }
+
+    /// @notice Add strategies to an operator set
+    /// @param operatorSetId The ID of the operator set to add strategies to
+    /// @param strategies The strategies to add
+    function addStrategiesToOperatorSet(uint32 operatorSetId, IStrategy[] calldata strategies) public onlyOwner {
+        _checkAreAllStrategiesWhitelisted(strategies);
+
+        ALLOCATION_MANAGER.addStrategiesToOperatorSet(address(this), operatorSetId, strategies);
+    }
+
+    /// @notice Remove strategies from an operator set
+    /// @param operatorSetId The ID of the operator set to remove strategies from
+    /// @param strategies The strategies to remove
+    function removeStrategiesFromOperatorSet(uint32 operatorSetId, IStrategy[] calldata strategies) public onlyOwner {
+        ALLOCATION_MANAGER.removeStrategiesFromOperatorSet(address(this), operatorSetId, strategies);
+    }
+
+    /// @notice Update the AllocationManager address
+    /// @param newAllocationManager The new AllocationManager address
+    function updateAllocationManagerAddress(
+        address newAllocationManager
+    ) public onlyOwner {
+        ALLOCATION_MANAGER = IAllocationManager(newAllocationManager);
+    }
+
+    /// @notice Update the AVSDirectory address
+    /// @param newAVSDirectory The new AVSDirectory address
+    function updateAVSDirectoryAddress(
+        address newAVSDirectory
+    ) public onlyOwner {
+        AVS_DIRECTORY = IAVSDirectory(newAVSDirectory);
+    }
+
+    /// @notice Update the StrategyManager address
+    /// @param newStrategyManager The new StrategyManager address
+    function updateStrategyManagerAddress(
+        address newStrategyManager
+    ) public onlyOwner {
+        STRATEGY_MANAGER = IStrategyManager(newStrategyManager);
+    }
+
+    /// @notice Update the DelegationManager address
+    /// @param newDelegationManager The new DelegationManager address
+    function updateDelegationManagerAddress(
+        address newDelegationManager
+    ) public onlyOwner {
+        DELEGATION_MANAGER = IDelegationManager(newDelegationManager);
+    }
+
+    /// @notice Update the OperatorsRegistry address
+    /// @param newOperatorsRegistry The new OperatorsRegistry address
+    function updateOperatorsRegistryAddress(
+        address newOperatorsRegistry
+    ) public onlyOwner {
+        OPERATORS_REGISTRY = IOperatorsRegistryV2(newOperatorsRegistry);
+    }
+
+    // ========== Internal helpers ========== //
+
+    /// @notice Check if ALL the given strategies are whitelisted.
+    /// If any of the strategies are not whitelisted, the function will revert.
+    /// @param strategies The strategies to check
+    function _checkAreAllStrategiesWhitelisted(
+        IStrategy[] calldata strategies
+    ) internal view {
+        for (uint256 i = 0; i < strategies.length; i++) {
+            require(_strategyWhitelist.contains(address(strategies[i])), UnauthorizedStrategy());
+        }
+    }
+
+    /// @notice Get all the active strategies at a given timestamp
+    /// @param timestamp The timestamp to get the active strategies at
+    /// @return The array of active strategies
+    function _getActiveStrategiesAt(
+        uint48 timestamp
+    ) internal view returns (IStrategy[] memory) {
+        uint256 activeCount = 0;
+        address[] memory activeStrategies = new address[](_strategyWhitelist.length());
+        for (uint256 i = 0; i < _strategyWhitelist.length(); i++) {
+            (address strategy, uint48 enabledAt, uint48 disabledAt) = _strategyWhitelist.at(i);
+
+            if (_wasEnabledAt(enabledAt, disabledAt, timestamp)) {
+                activeStrategies[activeCount] = strategy;
+                activeCount++;
+            }
+        }
+
+        // Resize the array to the actual number of active strategies
+        IStrategy[] memory result = new IStrategy[](activeCount);
+        for (uint256 i = 0; i < activeCount; i++) {
+            result[i] = IStrategy(activeStrategies[i]);
+        }
+        return result;
+    }
+
+    /// @notice Check if a map entry was active at a given timestamp.
+    /// @param enabledAt The enabled time of the map entry.
+    /// @param disabledAt The disabled time of the map entry.
+    /// @param timestamp The timestamp to check the map entry status at.
+    /// @return True if the map entry was active at the given timestamp, false otherwise.
+    function _wasEnabledAt(uint48 enabledAt, uint48 disabledAt, uint48 timestamp) internal pure returns (bool) {
+        return enabledAt != 0 && enabledAt <= timestamp && (disabledAt == 0 || disabledAt >= timestamp);
+    }
+
+    /// @notice Returns the timestamp of the current epoch.
+    /// @return timestamp The current epoch timestamp.
+    function _now() internal view returns (uint48) {
+        return OPERATORS_REGISTRY.getCurrentEpochStartTimestamp();
+    }
+}

--- a/contracts/src/contracts/OperatorsRegistryV2.sol
+++ b/contracts/src/contracts/OperatorsRegistryV2.sol
@@ -192,7 +192,9 @@ contract OperatorsRegistryV2 is IOperatorsRegistryV2, OwnableUpgradeable, UUPSUp
 
     /// @notice Update the rpc endpoint of an operator
     /// @param newRpcEndpoint The new rpc endpoint
-    function updateOperatorRpcEndpoint(string memory newRpcEndpoint) public {
+    function updateOperatorRpcEndpoint(
+        string memory newRpcEndpoint
+    ) public {
         address operator = msg.sender;
 
         require(_operatorAddresses.contains(operator), UnknownOperator());
@@ -203,7 +205,9 @@ contract OperatorsRegistryV2 is IOperatorsRegistryV2, OwnableUpgradeable, UUPSUp
 
     /// @notice Add an authorized signer to an operator
     /// @param signer The address of the new authorized signer
-    function addOperatorAuthorizedSigner(address signer) public {
+    function addOperatorAuthorizedSigner(
+        address signer
+    ) public {
         address operator = msg.sender;
 
         require(_operatorAddresses.contains(operator), UnknownOperator());
@@ -216,7 +220,9 @@ contract OperatorsRegistryV2 is IOperatorsRegistryV2, OwnableUpgradeable, UUPSUp
 
     /// @notice Pause an authorized signer from an operator
     /// @param signer The address of the signer
-    function pauseOperatorAuthorizedSigner(address signer) public {
+    function pauseOperatorAuthorizedSigner(
+        address signer
+    ) public {
         address operator = msg.sender;
 
         require(_operatorAddresses.contains(operator), UnknownOperator());
@@ -231,7 +237,9 @@ contract OperatorsRegistryV2 is IOperatorsRegistryV2, OwnableUpgradeable, UUPSUp
 
     /// @notice Unpause an authorized signer from an operator
     /// @param signer The address of the signer
-    function unpauseOperatorAuthorizedSigner(address signer) public {
+    function unpauseOperatorAuthorizedSigner(
+        address signer
+    ) public {
         address operator = msg.sender;
 
         require(_operatorAddresses.contains(operator), UnknownOperator());
@@ -243,7 +251,9 @@ contract OperatorsRegistryV2 is IOperatorsRegistryV2, OwnableUpgradeable, UUPSUp
 
     /// @notice Remove an authorized signer from an operator
     /// @param signer The address of the signer
-    function removeOperatorAuthorizedSigner(address signer) public {
+    function removeOperatorAuthorizedSigner(
+        address signer
+    ) public {
         address operator = msg.sender;
 
         require(_operatorAddresses.contains(operator), UnknownOperator());

--- a/contracts/src/contracts/OperatorsRegistryV2.sol
+++ b/contracts/src/contracts/OperatorsRegistryV2.sol
@@ -1,0 +1,378 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.27;
+
+import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+import {UUPSUpgradeable} from "@openzeppelin-v5.0.0/contracts/proxy/utils/UUPSUpgradeable.sol";
+import {Time} from "@openzeppelin-v5.0.0/contracts/utils/types/Time.sol";
+
+import {PauseableEnumerableSet} from "@symbiotic/middleware-sdk/libraries/PauseableEnumerableSet.sol";
+
+import {IOperatorsRegistryV2} from "../interfaces/IOperatorsRegistryV2.sol";
+import {IRestakingMiddlewareV1} from "../interfaces/IRestakingMiddlewareV1.sol";
+
+/// @title OperatorsRegistryV2
+/// @author Chainbound Developers <dev@chainbound.io>
+/// @notice A smart contract to store and manage Bolt operators
+contract OperatorsRegistryV2 is IOperatorsRegistryV2, OwnableUpgradeable, UUPSUpgradeable {
+    using PauseableEnumerableSet for PauseableEnumerableSet.AddressSet;
+
+    /// @notice The start timestamp of the contract, used as reference for time-based operations
+    uint48 public START_TIMESTAMP;
+
+    /// @notice The duration of an epoch in seconds, used for delaying opt-in/out operations
+    uint48 public EPOCH_DURATION;
+
+    /// @notice The set of bolt operator addresses.
+    PauseableEnumerableSet.AddressSet private _operatorAddresses;
+
+    /// @notice The map of operators, with their operator address as the key
+    mapping(address => Operator) public operators;
+
+    /// @notice the address of the EigenLayer restaking middleware
+    IRestakingMiddlewareV1 public EIGENLAYER_RESTAKING_MIDDLEWARE;
+
+    /// @notice The address of the Symbiotic restaking middleware
+    IRestakingMiddlewareV1 public SYMBIOTIC_RESTAKING_MIDDLEWARE;
+
+    /// @notice The map of operators to their set of authorized signers
+    mapping(address => PauseableEnumerableSet.AddressSet) private _authorizedSignersByOperator;
+
+    /// @dev This empty reserved space is put in place to allow future versions to add new
+    /// variables without shifting down storage in the inheritance chain.
+    /// See https://docs.openzeppelin.com/contracts/4.x/upgradeable#storage_gaps
+    /// This can be validated with the Openzeppelin Foundry Upgrades toolkit.
+    ///
+    /// Total storage slots: 50
+    uint256[43] private __gap;
+
+    // ===================== ERRORS ======================== //
+
+    error InvalidRpc();
+    error InvalidOperator();
+    error Unauthorized();
+    error UnknownOperator();
+    error OnlyRestakingMiddlewares();
+    error UnknownSigner();
+    error InvalidSigner();
+    error InvalidMiddleware(string reason);
+
+    // ========= Initializer & Proxy functionality ========= //
+
+    /// @notice Initialize the contract
+    /// @param owner The address of the owner
+    function initialize(address owner, uint48 epochDuration) public initializer {
+        __Ownable_init(owner);
+
+        EPOCH_DURATION = epochDuration;
+        START_TIMESTAMP = Time.timestamp();
+    }
+
+    /// @notice Re-initialize the contract after an upgrade
+    /// @param owner The address of the owner
+    function initializeV2(
+        address owner
+    ) public reinitializer(2) {
+        __Ownable_init(owner);
+    }
+
+    /// @notice Upgrade the contract
+    /// @param newImplementation The address of the new implementation
+    function _authorizeUpgrade(
+        address newImplementation
+    ) internal override onlyOwner {}
+
+    // ========= Modifiers ========= //
+
+    /// @notice Only one of the middleware contracts can call the function
+    modifier onlyMiddleware() {
+        require(
+            msg.sender == address(EIGENLAYER_RESTAKING_MIDDLEWARE)
+                || msg.sender == address(SYMBIOTIC_RESTAKING_MIDDLEWARE),
+            OnlyRestakingMiddlewares()
+        );
+        _;
+    }
+
+    // ========= Public helpers ========= //
+
+    /// @notice Returns the timestamp of when the current epoch started
+    /// @return timestamp The timestamp of the current epoch start
+    function getCurrentEpochStartTimestamp() public view returns (uint48) {
+        uint48 currentEpoch = (Time.timestamp() - START_TIMESTAMP) / EPOCH_DURATION;
+        return START_TIMESTAMP + currentEpoch * EPOCH_DURATION;
+    }
+
+    /// @notice Returns the timestamp of when the next epoch starts
+    /// @return timestamp The timestamp of the next epoch start
+    function getNextEpochStartTimestamp() public view returns (uint48) {
+        return getCurrentEpochStartTimestamp() + EPOCH_DURATION;
+    }
+
+    // ========= Operators functions ========= //
+    //
+    // The operator lifecycle looks as follows:
+    // 1. Register, and become active immediately. The operator can then manage their
+    //    restaking positions through the restaking protocol.
+    // 2. Pause, and become inactive. After a delay, the operator won't be slashable anymore,
+    //    but they can still manage and rebalance their positions.
+    // 3. Unpause, and become active again. After a delay, the operator can be slashed again.
+    // 4. Deregister, and become inactive. After a delay, the operator won't be part of the AVS anymore.
+
+    /// @notice Register an operator in the registry
+    /// @param operator The address of the operator
+    /// @param rpcEndpoint The rpc endpoint of the operator
+    /// @param extraData Arbitrary data the operator can provide as part of registration
+    /// @param authorizedSigners The addresses authorized to sign commitment on behalf of the operator.
+    function registerOperator(
+        address operator,
+        string memory rpcEndpoint,
+        string memory extraData,
+        address[] memory authorizedSigners
+    ) external onlyMiddleware {
+        require(bytes(rpcEndpoint).length > 0, InvalidRpc());
+        require(operator != address(0), InvalidOperator());
+
+        // Consider the operator active from the current timestamp onwards.
+        _operatorAddresses.register(Time.timestamp(), operator);
+        operators[operator] = Operator(operator, rpcEndpoint, msg.sender, extraData, authorizedSigners);
+
+        emit OperatorRegistered(operator, rpcEndpoint, msg.sender, extraData, authorizedSigners);
+    }
+
+    /// @notice Pause an operator in the registry
+    /// @param operator The address of the operator
+    /// @dev Only restaking middleware contracts can call this function.
+    /// @dev Paused operators are considered "inactive" until they are unpaused.
+    function pauseOperator(
+        address operator
+    ) external onlyMiddleware {
+        require(_operatorAddresses.contains(operator), UnknownOperator());
+
+        // Pause the operator at the end of the current epoch.
+        // Operators are still considered active until the start of the next epoch.
+        uint48 time = getCurrentEpochStartTimestamp() - 1;
+        _operatorAddresses.pause(time, operator);
+        emit OperatorPaused(operator, msg.sender);
+    }
+
+    /// @notice Unpause an operator in the registry, marking them as "active"
+    /// @param operator The address of the operator
+    /// @dev Only restaking middleware contracts can call this function
+    /// @dev Operators need to be paused and wait for EPOCH_DURATION() before they can be deregistered.
+    function unpauseOperator(
+        address operator
+    ) external onlyMiddleware {
+        require(_operatorAddresses.contains(operator), UnknownOperator());
+
+        // Unpause the operator at the start of the next epoch.
+        // Operators are still considered paused until the end of the current epoch.
+        uint48 time = getCurrentEpochStartTimestamp() - 1;
+        _operatorAddresses.unpause(time, EPOCH_DURATION, operator);
+        emit OperatorUnpaused(operator, msg.sender);
+    }
+
+    /// @notice Update the rpc endpoint of an operator
+    /// @param operator The address of the operator
+    /// @param newRpcEndpoint The new rpc endpoint
+    /// @dev Only restaking middleware contracts can call this function
+    function updateOperatorRpcEndpoint(address operator, string memory newRpcEndpoint) external onlyMiddleware {
+        require(_operatorAddresses.contains(operator), UnknownOperator());
+        require(bytes(newRpcEndpoint).length > 0, InvalidRpc());
+
+        operators[operator].rpcEndpoint = newRpcEndpoint;
+    }
+
+    /// @notice Add an authorized signer to an operator
+    /// @param operator The address of the operator
+    /// @param signer The address of the new authorized signer
+    /// @dev Only restaking middleware contracts can call this function
+    function addOperatorAuthorizedSigner(address operator, address signer) external onlyMiddleware {
+        require(_operatorAddresses.contains(operator), UnknownOperator());
+        require(signer != address(0), InvalidSigner());
+
+        // Register the signer as active from the current epoch onwards.
+        uint48 time = getCurrentEpochStartTimestamp();
+        _authorizedSignersByOperator[operator].register(time, signer);
+    }
+
+    /// @notice Pause an authorized signer from an operator
+    /// @param operator The address of the operator
+    /// @param signer The address of the signer
+    /// @dev Only restaking middleware contracts can call this function
+    function pauseOperatorAuthorizedSigner(address operator, address signer) external onlyMiddleware {
+        require(_operatorAddresses.contains(operator), UnknownOperator());
+        require(_authorizedSignersByOperator[operator].contains(signer), UnknownSigner());
+
+        // Pause the signer from the next epoch onwards. This ensures that the signer must wait for
+        // one full epoch before they aren't considered active anymore (to prevent trying to avoid
+        // being slashed).
+        uint48 time = getCurrentEpochStartTimestamp() - 1;
+        _authorizedSignersByOperator[operator].pause(time, signer);
+    }
+
+    /// @notice Unpause an authorized signer from an operator
+    /// @param operator The address of the operator
+    /// @param signer The address of the signer
+    /// @dev Only restaking middleware contracts can call this function
+    function unpauseOperatorAuthorizedSigner(address operator, address signer) external onlyMiddleware {
+        require(_operatorAddresses.contains(operator), UnknownOperator());
+        require(_authorizedSignersByOperator[operator].contains(signer), UnknownSigner());
+
+        uint48 time = getCurrentEpochStartTimestamp() - 1;
+        _authorizedSignersByOperator[operator].unpause(time, EPOCH_DURATION, signer);
+    }
+
+    /// @notice Remove an authorized signer from an operator
+    /// @param operator The address of the operator
+    /// @param signer The address of the signer
+    /// @dev Only restaking middleware contracts can call this function
+    function removeOperatorAuthorizedSigner(address operator, address signer) external onlyMiddleware {
+        require(_operatorAddresses.contains(operator), UnknownOperator());
+        require(_authorizedSignersByOperator[operator].contains(signer), UnknownSigner());
+
+        uint48 time = getCurrentEpochStartTimestamp() - 1;
+        _authorizedSignersByOperator[operator].unregister(time, signer);
+    }
+
+    /// @notice Deregister an operator from the registry
+    /// @param operator The address of the operator
+    /// @dev Only restaking middleware contracts can call this function
+    /// @dev Operators need to be paused and wait for EPOCH_DURATION() before they can be deregistered.
+    function deregisterOperator(
+        address operator
+    ) external onlyMiddleware {
+        require(_operatorAddresses.contains(operator), UnknownOperator());
+
+        // NOTE: we use the current epoch start timestamp - 1 to ensure that the operator is deregistered
+        // at the end of the current epoch. If we didn't do this, we would have to wait until the next
+        // epoch until the operator was actually deregistered.
+        uint48 time = getCurrentEpochStartTimestamp() - 1;
+        _operatorAddresses.unregister(time, EPOCH_DURATION, operator);
+        delete operators[operator];
+
+        emit OperatorDeregistered(operator, msg.sender);
+    }
+
+    /// @notice Returns all the operators saved in the registry, including inactive ones.
+    /// @return operators The array of operators
+    function getAllOperators() public view returns (Operator[] memory) {
+        Operator[] memory ops = new Operator[](_operatorAddresses.length());
+
+        for (uint256 i = 0; i < _operatorAddresses.length(); i++) {
+            (address operator,,) = _operatorAddresses.at(i);
+            ops[i] = operators[operator];
+        }
+
+        return ops;
+    }
+
+    /// @notice Returns the active operators in the registry.
+    /// @return operators The array of active operators.
+    function getActiveOperators() public view returns (Operator[] memory) {
+        address[] memory addrs = _operatorAddresses.getActive(Time.timestamp());
+
+        Operator[] memory ops = new Operator[](addrs.length);
+        for (uint256 i = 0; i < addrs.length; i++) {
+            ops[i] = operators[addrs[i]];
+        }
+
+        return ops;
+    }
+
+    /// @notice Returns the operator with the given signer address, and whether the operator is active
+    /// @param operator The address of the operator
+    /// @return op The operator struct
+    /// @return isActive True if the operator is active, false otherwise.
+    /// @return authorizedSigners The authorized signers of the operator
+    /// @dev Reverts if the operator does not exist
+    function getOperator(
+        address operator
+    ) public view returns (Operator memory op, bool isActive, address[] memory authorizedSigners) {
+        require(_operatorAddresses.contains(operator), UnknownOperator());
+
+        op = operators[operator];
+        isActive = _operatorAddresses.wasActiveAt(Time.timestamp(), operator);
+        authorizedSigners = _authorizedSignersByOperator[operator].getActive(Time.timestamp());
+    }
+
+    /// @notice Returns true if the given address is an operator in the registry.
+    /// @param operator The address of the operator.
+    /// @return isOperator True if the address is an operator, false otherwise.
+    function isOperator(
+        address operator
+    ) public view returns (bool) {
+        return _operatorAddresses.contains(operator);
+    }
+
+    /// @notice Returns true if the given operator is registered AND active.
+    /// @param operator The address of the operator
+    /// @return isActiveOperator True if the operator is active, false otherwise.
+    function isActiveOperator(
+        address operator
+    ) public view returns (bool) {
+        return _operatorAddresses.wasActiveAt(Time.timestamp(), operator);
+    }
+
+    /// @notice Returns the operator that has the given signer address as an authorized signer.
+    /// @param signerAddress The address of the signer.
+    /// @return op The operator struct.
+    /// @dev Reverts if no operator was found with the given signer address.
+    function getOperatorFromSignerAddress(
+        address signerAddress
+    ) public view returns (Operator memory op) {
+        // each operator can optionally have a list of authorized signers to make commitments on its behalf.
+        // we find the operator that has signerAddress in its authorized signers list.
+        for (uint256 i = 0; i < _operatorAddresses.length(); i++) {
+            (address operator,,) = _operatorAddresses.at(i);
+            if (_authorizedSignersByOperator[operator].contains(signerAddress)) {
+                return operators[operator];
+            }
+        }
+
+        revert UnknownOperator();
+    }
+
+    /// @notice Cleans up any expired operators (i.e. paused + EPOCH_DURATION has passed).
+    function cleanup() public {
+        for (uint256 i = 0; i < _operatorAddresses.length(); i++) {
+            (address operator,,) = _operatorAddresses.at(i);
+            if (_operatorAddresses.checkUnregister(Time.timestamp(), EPOCH_DURATION, operator)) {
+                _operatorAddresses.unregister(Time.timestamp(), EPOCH_DURATION, operator);
+                delete operators[operator];
+
+                emit OperatorDeregistered(operator, msg.sender);
+            }
+        }
+    }
+
+    // ========= Restaking Middlewres ========= //
+
+    /// @notice Update the address of a restaking middleware contract address
+    /// @param restakingProtocol The name of the restaking protocol
+    /// @param newMiddleware The address of the new restaking middleware
+    function updateRestakingMiddleware(
+        string calldata restakingProtocol,
+        IRestakingMiddlewareV1 newMiddleware
+    ) public onlyOwner {
+        require(address(newMiddleware) != address(0), InvalidMiddleware("Middleware address cannot be 0"));
+
+        bytes32 protocolNameHash = keccak256(abi.encodePacked(restakingProtocol));
+
+        if (protocolNameHash == keccak256("EIGENLAYER")) {
+            EIGENLAYER_RESTAKING_MIDDLEWARE = newMiddleware;
+        } else if (protocolNameHash == keccak256("SYMBIOTIC")) {
+            SYMBIOTIC_RESTAKING_MIDDLEWARE = newMiddleware;
+        } else {
+            revert InvalidMiddleware("Unknown restaking protocol, want EIGENLAYER or SYMBIOTIC");
+        }
+    }
+
+    /// @notice Check if a map entry was active at a given timestamp.
+    /// @param enabledTime The enabled time of the map entry.
+    /// @param disabledTime The disabled time of the map entry.
+    /// @param timestamp The timestamp to check the map entry status at.
+    /// @return True if the map entry was active at the given timestamp, false otherwise.
+    function _wasEnabledAt(uint48 enabledTime, uint48 disabledTime, uint48 timestamp) private pure returns (bool) {
+        return enabledTime != 0 && enabledTime <= timestamp && (disabledTime == 0 || disabledTime >= timestamp);
+    }
+}

--- a/contracts/src/contracts/SymbioticMiddlewareV2.sol
+++ b/contracts/src/contracts/SymbioticMiddlewareV2.sol
@@ -1,0 +1,416 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.27;
+
+import {UUPSUpgradeable} from "@openzeppelin-v5.0.0/contracts/proxy/utils/UUPSUpgradeable.sol";
+import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+import {Time} from "@openzeppelin-v5.0.0/contracts/utils/types/Time.sol";
+
+import {IVault} from "@symbiotic/core/interfaces/vault/IVault.sol";
+import {IVaultStorage} from "@symbiotic/core/interfaces/vault/IVaultStorage.sol";
+import {IEntity} from "@symbiotic/core/interfaces/common/IEntity.sol";
+import {IOperatorSpecificDelegator} from "@symbiotic/core/interfaces/delegator/IOperatorSpecificDelegator.sol";
+import {IBaseDelegator} from "@symbiotic/core/interfaces/delegator/IBaseDelegator.sol";
+import {IRegistry} from "@symbiotic/core/interfaces/common/IRegistry.sol";
+import {IOptInService} from "@symbiotic/core/interfaces/service/IOptInService.sol";
+import {Subnetwork} from "@symbiotic/core/contracts/libraries/Subnetwork.sol";
+import {INetworkMiddlewareService} from "@symbiotic/core/interfaces/service/INetworkMiddlewareService.sol";
+
+import {PauseableEnumerableSet} from "@symbiotic/middleware-sdk/libraries/PauseableEnumerableSet.sol";
+
+import {IOperatorsRegistryV2} from "../interfaces/IOperatorsRegistryV2.sol";
+import {IRestakingMiddlewareV1} from "../interfaces/IRestakingMiddlewareV1.sol";
+
+/// @title SymbioticMiddlewareV2
+/// @author Chainbound Developers <dev@chainbound.io>
+/// @notice This contract is responsible for interacting with the Symbiotic restaking protocol contracts.
+///         Responsibilities include: operator and vault management, stake aggregation across multiple vaults, and in the
+///         future: slashing & rewards.
+/// @dev This contract is based on the middleware-SDK.
+///
+/// For more information on extensions, see <https://docs.symbiotic.fi/middleware-sdk/extensions>.
+/// All public view functions are implemented in the `BaseMiddlewareReader`: <https://docs.symbiotic.fi/middleware-sdk/api-reference/middleware/BaseMiddlewareReader>
+contract SymbioticMiddlewareV2 is IRestakingMiddlewareV1, OwnableUpgradeable, UUPSUpgradeable {
+    using Subnetwork for address;
+    using PauseableEnumerableSet for PauseableEnumerableSet.AddressSet;
+
+    // ================ STORAGE ================== //
+    //
+    // Most of these constants replicate view methods in the BaseMiddlewareReader.
+    // See <https://docs.symbiotic.fi/middleware-sdk/api-reference/middleware/BaseMiddlewareReader> for more information.
+
+    /// @notice The name hash of this middleware.
+    bytes32 public NAME_HASH;
+
+    /// @notice The Symbiotic network: address(this)
+    address public NETWORK;
+
+    /// @notice The Symbiotic vault registry.
+    IRegistry public VAULT_REGISTRY;
+
+    /// @notice The Symbiotic operator registry.
+    IRegistry public OPERATOR_REGISTRY;
+
+    /// @notice The Symbiotic operator network opt-in service.
+    IOptInService public OPERATOR_NET_OPTIN;
+
+    /// @notice Default subnetwork.
+    uint96 internal constant DEFAULT_SUBNETWORK = 0;
+
+    /// @notice The address of the bolt registry
+    IOperatorsRegistryV2 public OPERATORS_REGISTRY;
+
+    /// @notice The set of whitelisted vaults for the network.
+    PauseableEnumerableSet.AddressSet private _vaultWhitelist;
+
+    /// @dev This empty reserved space is put in place to allow future versions to add new
+    /// variables without shift_initializeNetworkage in the inheritance chain.
+    /// See https://docs.openzeppelin.com/contracts/4.x/upgradeable#storage_gaps
+    /// This can be validated with the Openzeppelin Foundry Upgrades toolkit.
+    ///
+    /// Total storage slots: 50
+    uint256[42] private __gap;
+
+    /// @notice The vault delegator types.
+    /// @dev <https://docs.symbiotic.fi/modules/vault/introduction#3-limits-and-delegation-logic-module>
+    enum DelegatorType {
+        // Shared vaults
+        FULL_RESTAKE,
+        NETWORK_RESTAKE,
+        // Operator-specific vaults
+        OPERATOR_SPECIFIC,
+        OPERATOR_NETWORK_SPECIFIC
+    }
+
+    /// =================== EVENTS ====================== //
+
+    /// @notice Emitted when a vault was whitelisted.
+    event VaultWhitelisted(address indexed vault);
+
+    /// @notice Emitted when a vault was removed from the whitelist.
+    event VaultRemoved(address indexed vault);
+
+    /// @notice Emitted when a vault was paused.
+    event VaultPaused(address indexed vault);
+
+    /// @notice Emitted when a vault was unpaused.
+    event VaultUnpaused(address indexed vault);
+
+    /// =================== ERRORS ====================== //
+
+    error NotOperator();
+    error OperatorNotOptedIn();
+    error OperatorNotRegistered();
+
+    error NotVault();
+    error VaultNotInitialized();
+    error VaultAlreadyWhitelisted();
+    error UnauthorizedVault();
+    error NotOperatorSpecificVault();
+
+    /// =================== MODIFIERS =================== //
+
+    /// @notice Constructor for initializing the SymbioticMiddlewareV1 contract
+    /// @param owner The address of the owner
+    /// @param network The address of the network
+    /// @param vaultRegistry The address of the vault registry
+    /// @param operatorRegistry The address of the operator registry
+    /// @param operatorNetOptin The address of the operator network opt-in service
+    /// @dev We put all of the contract dependencies in the constructor to make it easier to (re-)deploy
+    ///      when dependencies are upgraded.
+    function initialize(
+        address owner,
+        address network,
+        IOperatorsRegistryV2 boltOperatorsRegistry,
+        IRegistry vaultRegistry,
+        IRegistry operatorRegistry,
+        IOptInService operatorNetOptin
+    ) public initializer {
+        __Ownable_init(owner);
+
+        NETWORK = network;
+        OPERATORS_REGISTRY = boltOperatorsRegistry;
+        VAULT_REGISTRY = vaultRegistry;
+        OPERATOR_REGISTRY = operatorRegistry;
+        OPERATOR_NET_OPTIN = operatorNetOptin;
+        NAME_HASH = keccak256("SYMBIOTIC");
+    }
+
+    /// @notice Re-initialize the contract after an upgrade
+    /// @param owner The address of the owner
+    function initializeV2(
+        address owner
+    ) public reinitializer(2) {
+        __Ownable_init(owner);
+    }
+
+    /// @notice Upgrade the contract
+    /// @param newImplementation The address of the new implementation
+    function _authorizeUpgrade(
+        address newImplementation
+    ) internal override onlyOwner {}
+
+    // ================ OPERATORS ===================== //
+
+    /// @notice Register an operator in the registry.
+    function registerOperator(
+        string calldata rpcEndpoint,
+        string calldata extraData,
+        address[] memory authorizedSigners
+    ) public {
+        require(OPERATOR_REGISTRY.isEntity(msg.sender), NotOperator());
+
+        require(OPERATOR_NET_OPTIN.isOptedIn(msg.sender, NETWORK), OperatorNotOptedIn());
+
+        OPERATORS_REGISTRY.registerOperator(msg.sender, rpcEndpoint, extraData, authorizedSigners);
+    }
+
+    /// @notice Deregister an operator from the registry.
+    function deregisterOperator() public {
+        OPERATORS_REGISTRY.pauseOperator(msg.sender);
+        // TODO(V3): in the future we may not want to remove the vaults immediately, in case
+        // of a pending penalty that the operator is trying to avoid.
+    }
+
+    /// @notice Update your RPC endpoint as an operator.
+    /// @param rpcEndpoint The new rpc endpoint.
+    function updateOperatorRpcEndpoint(
+        string calldata rpcEndpoint
+    ) public {
+        OPERATORS_REGISTRY.updateOperatorRpcEndpoint(msg.sender, rpcEndpoint);
+    }
+
+    // ================ OPERATOR VIEW METHODS =================== //
+
+    /// @notice Gets the operator stake for the vault.
+    /// @param operator The address of the operator.
+    /// @param collateral The address of the collateral.
+    /// @return The operator stake.
+    function getOperatorStake(address operator, address collateral) public view returns (uint256) {
+        // TODO(V2): only do this for active operators & vaults?
+        return getOperatorStakeAt(operator, collateral, _now());
+    }
+
+    /// @notice Gets the operator stake for the vault at a specific timestamp.
+    /// @param operator The address of the operator.
+    /// @param collateral The address of the collateral.
+    /// @param timestamp The timestamp to get the stake at.
+    /// @return The operator stake.
+    function getOperatorStakeAt(address operator, address collateral, uint48 timestamp) public view returns (uint256) {
+        // TODO(V2): check if vault and operator are registered, associated & active
+        // Distinguish between shared vaults and operator vaults
+
+        // Get vault for collateral
+        address vault;
+        for (uint256 i = 0; i < _vaultWhitelist.length(); i++) {
+            (address _vault, uint48 enabledTime, uint48 disabledTime) = _vaultWhitelist.at(i);
+
+            if (!_wasEnabledAt(enabledTime, disabledTime, timestamp)) {
+                // Set the token, keep the amount at 0
+                continue;
+            }
+
+            if (IVaultStorage(_vault).collateral() == collateral) {
+                vault = _vault;
+                break;
+            }
+        }
+
+        // If vault is not found (inactive or not whitelisted), return 0
+        if (vault == address(0)) {
+            return 0;
+        }
+
+        bytes32 networkId = NETWORK.subnetwork(DEFAULT_SUBNETWORK);
+        return IBaseDelegator(IVault(vault).delegator()).stakeAt(networkId, operator, timestamp, "");
+    }
+
+    /// @notice Gets the operator collaterals, as a tuple of arrays.
+    /// @param operator The address of the operator.
+    /// @return The operator collaterals and amounts, as a tuple of arrays with a
+    /// shared index.
+    function getOperatorCollaterals(
+        address operator
+    ) public view returns (address[] memory, uint256[] memory) {
+        address[] memory tokens = new address[](_vaultWhitelist.length());
+        uint256[] memory amounts = new uint256[](_vaultWhitelist.length());
+
+        bytes32 networkId = NETWORK.subnetwork(DEFAULT_SUBNETWORK);
+
+        for (uint256 i = 0; i < _vaultWhitelist.length(); i++) {
+            // TODO(V2): only get active vaults
+            (address vault, uint48 enabledTime, uint48 disabledTime) = _vaultWhitelist.at(i);
+
+            if (!_wasEnabledAt(enabledTime, disabledTime, _now())) {
+                // Set the token, keep the amount at 0
+                tokens[i] = IVaultStorage(vault).collateral();
+                continue;
+            }
+
+            tokens[i] = IVaultStorage(vault).collateral();
+            amounts[i] = IBaseDelegator(IVault(vault).delegator()).stake(networkId, operator);
+        }
+
+        return (tokens, amounts);
+    }
+
+    // ================ VAULTS ===================== //
+
+    /// @notice Whitelists a vault for the network.
+    /// @param vault The address of the vault
+    function whitelistVault(
+        address vault
+    ) public onlyOwner {
+        // Validate the vault
+        _validateVault(vault);
+
+        // Registers and enables the vault
+        _vaultWhitelist.register(_now(), vault);
+
+        emit VaultWhitelisted(vault);
+    }
+
+    /// @notice Removes a whitelisted vault from the network.
+    /// @param vault The address of the vault
+    function removeVault(
+        address vault
+    ) public onlyOwner {
+        // NOTE: we use _now() - 1 to ensure that the vault is removed in the current epoch.
+        _vaultWhitelist.unregister(_now() - 1, OPERATORS_REGISTRY.EPOCH_DURATION(), vault);
+        emit VaultRemoved(vault);
+    }
+
+    /// @notice Pause a vault across the network (whitelist, operator-specific, and shared).
+    /// @param vault The address of the vault
+    function pauseVault(
+        address vault
+    ) public onlyOwner {
+        // NOTE: we use _now() - 1 to ensure that the vault is paused in the current epoch.
+        // If we didn't do this, we would have to wait until the next epoch until the vault was actually paused.
+        _vaultWhitelist.pause(_now() - 1, vault);
+        emit VaultPaused(vault);
+    }
+
+    /// @notice Unpause a vault
+    /// @param vault The address of the vault
+    function unpauseVault(
+        address vault
+    ) public onlyOwner {
+        _vaultWhitelist.unpause(_now(), OPERATORS_REGISTRY.EPOCH_DURATION(), vault);
+        emit VaultUnpaused(vault);
+    }
+
+    /// @notice Gets all whitelisted vaults, including inactive ones.
+    /// @return An array of whitelisted vaults.
+    function getWhitelistedVaults() public view returns (address[] memory) {
+        address[] memory vaults = new address[](_vaultWhitelist.length());
+
+        for (uint256 i = 0; i < _vaultWhitelist.length(); i++) {
+            (vaults[i],,) = _vaultWhitelist.at(i);
+        }
+
+        return vaults;
+    }
+
+    /// @notice Gets all _active_ whitelisted vaults.
+    /// @return An array of active whitelisted vaults.
+    function getActiveWhitelistedVaults() public view returns (address[] memory) {
+        address[] memory tempVaults = new address[](_vaultWhitelist.length());
+        uint256 activeCount;
+
+        // First pass: count active vaults
+        for (uint256 i = 0; i < _vaultWhitelist.length(); i++) {
+            (address vault, uint48 enabledTime, uint48 disabledTime) = _vaultWhitelist.at(i);
+            if (_wasEnabledAt(enabledTime, disabledTime, _now())) {
+                tempVaults[activeCount] = vault;
+                activeCount++;
+            }
+        }
+
+        // Create correctly sized array and copy active vaults
+        address[] memory activeVaults = new address[](activeCount);
+        for (uint256 i = 0; i < activeCount; i++) {
+            activeVaults[i] = tempVaults[i];
+        }
+
+        return activeVaults;
+    }
+
+    /// @notice Returns the total number of whitelisted vaults.
+    /// @return The total number of whitelisted vaults.
+    function vaultWhitelistLength() public view returns (uint256) {
+        return _vaultWhitelist.length();
+    }
+
+    /// @notice Returns whether the vault is active in this epoch.
+    /// @param vault The address of the vault
+    /// @return True if the vault is active, false otherwise.
+    function isVaultActive(
+        address vault
+    ) public view returns (bool) {
+        return _vaultWhitelist.wasActiveAt(_now(), vault);
+    }
+
+    /// @notice Validates if a vault is properly initialized and registered
+    /// @param vault The vault address to validate
+    /// @dev Adapted from https://github.com/symbioticfi/middleware-sdk/blob/68334572da818cc547aca8e729321e98df97a2a8/src/managers/VaultManager.sol
+    function _validateVault(
+        address vault
+    ) private view {
+        require(VAULT_REGISTRY.isEntity(vault), NotVault());
+        require(IVault(vault).isInitialized(), VaultNotInitialized());
+
+        if (_vaultWhitelist.contains(vault)) {
+            revert VaultAlreadyWhitelisted();
+        }
+
+        // TODO(V3): slasher checks:
+
+        // uint48 vaultEpoch = IVault(vault).epochDuration();
+        // address slasher = IVault(vault).slasher();
+        // if (slasher != address(0)) {
+        //     uint64 slasherType = IEntity(slasher).TYPE();
+        //     if (slasherType == uint64(SlasherType.VETO)) {
+        //         vaultEpoch -= IVetoSlasher(slasher).vetoDuration();
+        //     } else if (slasherType > uint64(SlasherType.VETO)) {
+        //         revert UnknownSlasherType();
+        //     }
+        // }
+
+        // if (vaultEpoch < SLASHING_WINDOW) {
+        //     revert VaultEpochTooShort();
+        // }
+    }
+
+    /// @notice Validates if a vault has an operator-specific delegator type (OPERATOR_SPECIFIC or OPERATOR_NETWORK_SPECIFIC)
+    /// @param operator The operator address
+    /// @param vault The vault address
+    function _validateOperatorVault(address operator, address vault) internal view {
+        address delegator = IVault(vault).delegator();
+        uint64 delegatorType = IEntity(delegator).TYPE();
+        if (
+            (
+                delegatorType != uint64(DelegatorType.OPERATOR_SPECIFIC)
+                    && delegatorType != uint64(DelegatorType.OPERATOR_NETWORK_SPECIFIC)
+            ) || IOperatorSpecificDelegator(delegator).operator() != operator
+        ) {
+            revert NotOperatorSpecificVault();
+        }
+    }
+
+    // ========= HELPER FUNCTIONS =========
+
+    /// @notice Check if a map entry was active at a given timestamp.
+    /// @param enabledTime The enabled time of the map entry.
+    /// @param disabledTime The disabled time of the map entry.
+    /// @param timestamp The timestamp to check the map entry status at.
+    /// @return True if the map entry was active at the given timestamp, false otherwise.
+    function _wasEnabledAt(uint48 enabledTime, uint48 disabledTime, uint48 timestamp) private pure returns (bool) {
+        return enabledTime != 0 && enabledTime <= timestamp && (disabledTime == 0 || disabledTime >= timestamp);
+    }
+
+    /// @notice Returns the timestamp of the current epoch.
+    /// @return timestamp The current epoch timestamp.
+    function _now() internal view returns (uint48) {
+        return OPERATORS_REGISTRY.getCurrentEpochStartTimestamp();
+    }
+}

--- a/contracts/src/contracts/SymbioticMiddlewareV2.sol
+++ b/contracts/src/contracts/SymbioticMiddlewareV2.sol
@@ -171,14 +171,6 @@ contract SymbioticMiddlewareV2 is IRestakingMiddlewareV1, OwnableUpgradeable, UU
         // of a pending penalty that the operator is trying to avoid.
     }
 
-    /// @notice Update your RPC endpoint as an operator.
-    /// @param rpcEndpoint The new rpc endpoint.
-    function updateOperatorRpcEndpoint(
-        string calldata rpcEndpoint
-    ) public {
-        OPERATORS_REGISTRY.updateOperatorRpcEndpoint(msg.sender, rpcEndpoint);
-    }
-
     // ================ OPERATOR VIEW METHODS =================== //
 
     /// @notice Gets the operator stake for the vault.

--- a/contracts/src/interfaces/IOperatorsRegistryV2.sol
+++ b/contracts/src/interfaces/IOperatorsRegistryV2.sol
@@ -71,10 +71,8 @@ interface IOperatorsRegistryV2 {
     ) external;
 
     /// @notice Update the rpc endpoint of an operator
-    /// @param operator The address of the operator
     /// @param rpcEndpoint The new rpc endpoint
-    /// @dev Only restaking middleware contracts can call this function
-    function updateOperatorRpcEndpoint(address operator, string memory rpcEndpoint) external;
+    function updateOperatorRpcEndpoint(string memory rpcEndpoint) external;
 
     /// @notice Pause an operator in the registry
     /// @param operator The address of the operator

--- a/contracts/src/interfaces/IOperatorsRegistryV2.sol
+++ b/contracts/src/interfaces/IOperatorsRegistryV2.sol
@@ -13,8 +13,6 @@ interface IOperatorsRegistryV2 {
         string rpcEndpoint;
         address restakingMiddleware;
         string extraData;
-        // Field introduced in V2
-        address[] authorizedSigners;
     }
 
     /// @notice Emitted when a new operator is registered

--- a/contracts/src/interfaces/IOperatorsRegistryV2.sol
+++ b/contracts/src/interfaces/IOperatorsRegistryV2.sol
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.27;
+
+import {IRestakingMiddlewareV1} from "./IRestakingMiddlewareV1.sol";
+
+/// @title IOperatorsRegistryV2
+/// @author Chainbound Developers <dev@chainbound.io>
+/// @notice An interface for the OperatorsRegistryV2 contract
+interface IOperatorsRegistryV2 {
+    /// @notice Operator struct
+    struct Operator {
+        address signer;
+        string rpcEndpoint;
+        address restakingMiddleware;
+        string extraData;
+        // Field introduced in V2
+        address[] authorizedSigners;
+    }
+
+    /// @notice Emitted when a new operator is registered
+    /// @param operator The address of the operator
+    /// @param rpcEndpoint The rpc endpoint of the operator
+    /// @param restakingMiddleware The address of the restaking middleware
+    /// @param extraData Arbitrary data the operator can provide as part of registration
+    /// @param authorizedSigners The addresses authorized to sign commitment on behalf of the operator.
+    event OperatorRegistered(
+        address operator, string rpcEndpoint, address restakingMiddleware, string extraData, address[] authorizedSigners
+    );
+
+    /// @notice Emitted when an operator is deregistered
+    /// @param operator The address of the operator
+    /// @param restakingMiddleware The address of the restaking middleware
+    event OperatorDeregistered(address operator, address restakingMiddleware);
+
+    /// @notice Emitted when an operator is paused
+    /// @param operator The address of the operator
+    /// @param restakingMiddleware The address of the restaking middleware
+    event OperatorPaused(address operator, address restakingMiddleware);
+
+    /// @notice Emitted when an operator is unpaused
+    /// @param operator The address of the operator
+    /// @param restakingMiddleware The address of the restaking middleware
+    event OperatorUnpaused(address operator, address restakingMiddleware);
+
+    /// @notice Returns the start timestamp of the registry contract
+    function START_TIMESTAMP() external view returns (uint48);
+
+    /// @notice Returns the duration of an epoch in seconds
+    function EPOCH_DURATION() external view returns (uint48);
+
+    /// @notice Returns the address of the EigenLayer restaking middleware
+    function EIGENLAYER_RESTAKING_MIDDLEWARE() external view returns (IRestakingMiddlewareV1);
+
+    /// @notice Returns the address of the Symbiotic restaking middleware
+    function SYMBIOTIC_RESTAKING_MIDDLEWARE() external view returns (IRestakingMiddlewareV1);
+
+    /// @notice Register an operator in the registry
+    /// @param operator The address of the operator
+    /// @param rpcEndpoint The rpc endpoint of the operator
+    /// @param extraData Arbitrary data the operator can provide as part of registration
+    /// @param authorizedSigners The addresses authorized to sign commitment on behalf of the operator.
+    function registerOperator(
+        address operator,
+        string memory rpcEndpoint,
+        string memory extraData,
+        address[] memory authorizedSigners
+    ) external;
+
+    /// @notice Deregister an operator from the registry
+    /// @param operator The address of the operator
+    function deregisterOperator(
+        address operator
+    ) external;
+
+    /// @notice Update the rpc endpoint of an operator
+    /// @param operator The address of the operator
+    /// @param rpcEndpoint The new rpc endpoint
+    /// @dev Only restaking middleware contracts can call this function
+    function updateOperatorRpcEndpoint(address operator, string memory rpcEndpoint) external;
+
+    /// @notice Pause an operator in the registry
+    /// @param operator The address of the operator
+    function pauseOperator(
+        address operator
+    ) external;
+
+    /// @notice Unpause an operator in the registry, marking them as "active"
+    /// @param operator The address of the operator
+    function unpauseOperator(
+        address operator
+    ) external;
+
+    /// @notice Returns all the operators saved in the registry, including inactive ones.
+    /// @return operators The array of operators
+    function getAllOperators() external view returns (Operator[] memory);
+
+    /// @notice Returns the active operators in the registry.
+    /// @return operators The array of active operators.
+    function getActiveOperators() external view returns (Operator[] memory);
+
+    /// @notice Get an operator struct and a bool indicating whether it is active
+    /// @param operator The address of the operator
+    /// @return op The operator struct
+    /// @return isActive True if the operator is active, false otherwise.
+    /// @return authorizedSigners The authorized signers of the operator
+    function getOperator(
+        address operator
+    ) external view returns (Operator memory op, bool isActive, address[] memory authorizedSigners);
+
+    /// @notice Returns true if the given address is an operator in the registry.
+    /// @param operator The address of the operator.
+    /// @return isOperator True if the address is an operator, false otherwise.
+    function isOperator(
+        address operator
+    ) external view returns (bool);
+
+    /// @notice Returns true if the given operator is registered AND active.
+    /// @param operator The address of the operator
+    /// @return isActiveOperator True if the operator is active, false otherwise.
+    function isActiveOperator(
+        address operator
+    ) external view returns (bool);
+
+    /// @notice Cleans up any expired operators (i.e. paused + IMMUTABLE_PERIOD has passed).
+    function cleanup() external;
+
+    /// @notice Returns the timestamp of when the current epoch started
+    function getCurrentEpochStartTimestamp() external view returns (uint48);
+}

--- a/contracts/src/interfaces/IOperatorsRegistryV2.sol
+++ b/contracts/src/interfaces/IOperatorsRegistryV2.sol
@@ -72,7 +72,9 @@ interface IOperatorsRegistryV2 {
 
     /// @notice Update the rpc endpoint of an operator
     /// @param rpcEndpoint The new rpc endpoint
-    function updateOperatorRpcEndpoint(string memory rpcEndpoint) external;
+    function updateOperatorRpcEndpoint(
+        string memory rpcEndpoint
+    ) external;
 
     /// @notice Pause an operator in the registry
     /// @param operator The address of the operator

--- a/contracts/test/holesky/EigenLayerMiddlewareV1.t.sol
+++ b/contracts/test/holesky/EigenLayerMiddlewareV1.t.sol
@@ -20,7 +20,7 @@ import {IOperatorsRegistryV1} from "../../src/interfaces/IOperatorsRegistryV1.so
 import {EigenLayerMiddlewareV1} from "../../src/contracts/EigenLayerMiddlewareV1.sol";
 import {IWETH} from "../util/IWETH.sol";
 
-contract EigenLayerMiddlewareV1Test is Test {
+contract EigenLayerMiddlewareV1HoleskyTest is Test {
     OperatorsRegistryV1 registry;
     EigenLayerMiddlewareV1 middleware;
 

--- a/contracts/test/holesky/SymbioticMiddleware.t.sol
+++ b/contracts/test/holesky/SymbioticMiddleware.t.sol
@@ -21,7 +21,7 @@ import {Subnetwork} from "@symbiotic/core/contracts/libraries/Subnetwork.sol";
 
 import {IERC20} from "@openzeppelin-v4.9.0/contracts/interfaces/IERC20.sol";
 
-contract SymbioticMiddlewareHoleskyTest is Test {
+contract SymbioticMiddlewareV1HoleskyTest is Test {
     using Subnetwork for address;
 
     uint48 EPOCH_DURATION = 1 days;

--- a/contracts/test/mainnet/EigenLayerMiddlewareV1.t.sol
+++ b/contracts/test/mainnet/EigenLayerMiddlewareV1.t.sol
@@ -33,7 +33,7 @@ interface IDelegationManagerPreELIP002 {
     ) external;
 }
 
-contract EigenLayerMiddlewareV1Test is Test {
+contract EigenLayerMiddlewareV1MainnetTest is Test {
     OperatorsRegistryV1 registry;
     EigenLayerMiddlewareV1 middleware;
 

--- a/contracts/test/mainnet/EigenLayerMiddlewareV4.t.sol
+++ b/contracts/test/mainnet/EigenLayerMiddlewareV4.t.sol
@@ -232,4 +232,26 @@ contract EigenLayerMiddlewareV4Test is Test {
         assertEq(authSigners.length, authorizedSigners.length);
         assertEq(authSigners[0], authorizedSigner);
     }
+
+    function testPauseUnpauseOperator() public {
+        address[] memory authorizedSigners = new address[](1);
+        authorizedSigners[0] = authorizedSigner;
+
+        // 1. register the operator
+        _registerOperator(operator, "http://stopjava.com", "operator1", authorizedSigners);
+
+        // 2. pause the operator by deregistering it from the AVS
+        vm.prank(operator);
+        middleware.deregisterOperatorFromAVS();
+
+        // 3. check that the operator is paused immediately
+        (IOperatorsRegistryV2.Operator memory opData, bool isActive, address[] memory authSigners) =
+            registry.getOperator(operator);
+        assertEq(isActive, false);
+
+        // 4. try to unpause the operator and check that it fails
+        vm.prank(operator);
+        vm.expectRevert(PauseableEnumerableSet.ImmutablePeriodNotPassed.selector);
+        middleware.unpauseOperator();
+    }
 }

--- a/contracts/test/mainnet/EigenLayerMiddlewareV4.t.sol
+++ b/contracts/test/mainnet/EigenLayerMiddlewareV4.t.sol
@@ -1,0 +1,219 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.27;
+
+import {Test, console} from "forge-std/Test.sol";
+import {IERC20} from "@openzeppelin-v4.9.0/contracts/token/ERC20/IERC20.sol";
+import {
+    IAllocationManager, IAllocationManagerTypes
+} from "@eigenlayer/src/contracts/interfaces/IAllocationManager.sol";
+import {AllocationManagerStorage} from "@eigenlayer/src/contracts/core/AllocationManagerStorage.sol";
+import {IDelegationManager} from "@eigenlayer/src/contracts/interfaces/IDelegationManager.sol";
+import {IStrategyManager} from "@eigenlayer/src/contracts/interfaces/IStrategyManager.sol";
+import {IStrategy} from "@eigenlayer/src/contracts/interfaces/IStrategy.sol";
+import {ISignatureUtils} from "@eigenlayer/src/contracts/interfaces/ISignatureUtils.sol";
+import {IAVSDirectory} from "@eigenlayer/src/contracts/interfaces/IAVSDirectory.sol";
+import {OperatorSet} from "@eigenlayer/src/contracts/libraries/OperatorSetLib.sol";
+
+import {OperatorsRegistryV2} from "../../src/contracts/OperatorsRegistryV2.sol";
+import {IOperatorsRegistryV2} from "../../src/interfaces/IOperatorsRegistryV2.sol";
+import {EigenLayerMiddlewareV4} from "../../src/contracts/EigenLayerMiddlewareV4.sol";
+
+// This is needed because the registerAsOperator function has changed in ELIP-002
+// and we need to manually call it with the pre-ELIP-002 parameters
+interface IDelegationManagerPreELIP002 {
+    struct OperatorDetails {
+        address __deprecated_earningsReceiver;
+        address delegationApprover;
+        uint32 stakerOptOutWindowBlocks;
+    }
+
+    function registerAsOperator(
+        OperatorDetails calldata registeringOperatorDetails,
+        string calldata metadataURI
+    ) external;
+}
+
+contract EigenLayerMiddlewareV4Test is Test {
+    OperatorsRegistryV2 registry;
+    EigenLayerMiddlewareV4 middleware;
+
+    address admin;
+    address staker;
+    address operator;
+    uint256 operatorSk;
+    address authorizedSigner;
+
+    IDelegationManager mainnetDelegationManager = IDelegationManager(0x39053D51B77DC0d36036Fc1fCc8Cb819df8Ef37A);
+    IStrategyManager mainnetStrategyManager = IStrategyManager(0x858646372CC42E1A627fcE94aa7A7033e7CF075A);
+    IAVSDirectory mainnetAVSDirectory = IAVSDirectory(0x135DDa560e946695d6f155dACaFC6f1F25C1F5AF);
+
+    IERC20 mainnetCbEth = IERC20(0xBe9895146f7AF43049ca1c1AE358B0541Ea49704);
+    IStrategy mainnetCbEthStrategy = IStrategy(0x54945180dB7943c0ed0FEE7EdaB2Bd24620256bc);
+
+    // Note: operators can gate staker delegations behind a signature check. when this is disabled,
+    // a signature is still required but it can be empty. This is a no-op signature.
+    ISignatureUtils.SignatureWithExpiry NoOpSignature = ISignatureUtils.SignatureWithExpiry(bytes(""), 0);
+
+    function setUp() public {
+        vm.createSelectFork("https://geth-mainnet.bolt.chainbound.io");
+
+        admin = makeAddr("admin");
+        staker = makeAddr("staker");
+        (operator, operatorSk) = makeAddrAndKey("operator");
+        authorizedSigner = makeAddr("authorizedSigner");
+
+        vm.startPrank(admin);
+
+        // --- Deploy the OperatorsRegistry ---
+        registry = new OperatorsRegistryV2();
+        registry.initialize(admin, 1 days);
+
+        // --- Deploy the EL middleware ---
+        middleware = new EigenLayerMiddlewareV4();
+        middleware.initialize(
+            admin,
+            registry,
+            mainnetAVSDirectory,
+            IAllocationManager(address(0)),
+            mainnetDelegationManager,
+            mainnetStrategyManager
+        );
+
+        // 1. Whitelist the strategies in the middleware
+        middleware.whitelistStrategy(address(mainnetCbEthStrategy));
+
+        // check that the strategies are whitelisted
+        IStrategy[] memory whitelistedStrategies = middleware.getActiveWhitelistedStrategies();
+        assertEq(whitelistedStrategies.length, 1);
+        assertEq(address(whitelistedStrategies[0]), address(mainnetCbEthStrategy));
+
+        // IStrategy[] memory strategies = new IStrategy[](1);
+        // strategies[0] = mainnetStEthStrategy;
+
+        // IAllocationManagerTypes.CreateSetParams[] memory createParams = new IAllocationManagerTypes.CreateSetParams[](1);
+        // createParams[0] = IAllocationManagerTypes.CreateSetParams({operatorSetId: 0, strategies: strategies});
+
+        // // 2. Create an OperatorSet in the middleware to handle all strategies
+        // middleware.createOperatorSets(createParams);
+
+        // 3. Add the middleware address to the registry
+        registry.updateRestakingMiddleware("EIGENLAYER", middleware);
+
+        // 4. Update the metadata URI
+        middleware.updateAVSMetadataURI("AVS_DIRECTORY", "https://grugbrain.dev");
+
+        vm.stopPrank();
+    }
+
+    /// Helper function to register an operator
+    function _registerOperator(
+        address signer,
+        string memory rpcEndpoint,
+        string memory extraData,
+        address[] memory authorizedSigners
+    ) public {
+        // 1. Register the new EL operator in DelegationManager
+        // manually call the registerAsOperator function with the pre-ELIP-002 parameters
+        address earningsReceiver = address(1);
+        address delegationApprover = address(0);
+        uint32 stakerOptOutWindowBlocks = 0;
+        vm.prank(signer);
+        IDelegationManagerPreELIP002(address(mainnetDelegationManager)).registerAsOperator(
+            IDelegationManagerPreELIP002.OperatorDetails(earningsReceiver, delegationApprover, stakerOptOutWindowBlocks),
+            "https://some-meetadata.uri.com"
+        );
+
+        // 2. As a operator, I can now opt-in into an AVS by interacting with the ServiceManager.
+        // Two steps happen:
+        // i. I call the AVS’ ServiceManager.registerOperatorToAVS. The payload is a signature whose digest consists of:
+        //     a. my operator address
+        //     b. the AVS’ ServiceManager contract address
+        //     c. a salt
+        //     d. an expiry
+        // ii. The contract forwards the call to the AVSDirectory.registerOperatorToAVS to
+        // that msg.sender is the AVS contract. Upon successful verification of the signature,
+        // the operator is considered REGISTERED in a mapping avsOperatorStatus[msg.sender][operator].
+
+        // Calculate the digest hash
+        bytes32 operatorRegistrationDigestHash = mainnetAVSDirectory.calculateOperatorAVSRegistrationDigestHash({
+            operator: signer,
+            avs: address(middleware),
+            salt: bytes32(0),
+            expiry: UINT256_MAX
+        });
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(operatorSk, operatorRegistrationDigestHash);
+        bytes memory operatorRawSignature = abi.encodePacked(r, s, v);
+        ISignatureUtils.SignatureWithSaltAndExpiry memory operatorSignature =
+            ISignatureUtils.SignatureWithSaltAndExpiry(operatorRawSignature, bytes32(0), UINT256_MAX);
+
+        vm.prank(signer);
+        middleware.registerOperatorToAVS(rpcEndpoint, extraData, operatorSignature, authorizedSigners);
+
+        vm.warp(block.timestamp + 1 days);
+
+        (IOperatorsRegistryV2.Operator memory opData, bool isActive, address[] memory authSigners) =
+            registry.getOperator(signer);
+        assertEq(opData.signer, signer);
+        assertEq(opData.rpcEndpoint, rpcEndpoint);
+        assertEq(opData.extraData, extraData);
+        assertEq(opData.restakingMiddleware, address(middleware));
+        assertEq(isActive, true);
+        assertEq(authSigners.length, authorizedSigners.length);
+    }
+
+    function testRegister() public {
+        address[] memory authorizedSigners = new address[](1);
+        authorizedSigners[0] = operator;
+
+        _registerOperator(operator, "http://stopjava.com", "operator1", authorizedSigners);
+    }
+
+    function testRegisterAndDepositCollateral() public {
+        // 0. Mint steth to the staker
+        assertEq(address(mainnetCbEthStrategy.underlyingToken()), address(mainnetCbEth));
+        deal(address(mainnetCbEth), staker, 100 ether);
+        assertEq(mainnetCbEth.balanceOf(staker), 100 ether);
+
+        // 1. Deposit weth collateral to the operator
+        vm.prank(staker);
+        mainnetCbEth.approve(address(mainnetStrategyManager), 100 ether);
+        vm.prank(staker);
+        uint256 shares = mainnetStrategyManager.depositIntoStrategy(mainnetCbEthStrategy, mainnetCbEth, 100 ether);
+        assertEq(mainnetCbEthStrategy.sharesToUnderlyingView(shares), 99_999_999_999_999_999_999);
+
+        // 2. Register the operator in both EL and the bolt AVS
+        address[] memory authorizedSigners = new address[](1);
+        authorizedSigners[0] = authorizedSigner;
+        _registerOperator(operator, "http://stopjava.com", "operator1", authorizedSigners);
+
+        // 3. Delegate funds from the staker to the operator
+        vm.prank(staker);
+        mainnetDelegationManager.delegateTo(operator, NoOpSignature, bytes32(0));
+        assertEq(mainnetDelegationManager.delegatedTo(staker), operator);
+
+        // make sure the strategies are active in the middleware
+        IStrategy[] memory activeStrats = middleware.getActiveWhitelistedStrategies();
+        assertEq(activeStrats.length, 1);
+        assertEq(address(activeStrats[0]), address(mainnetCbEthStrategy));
+
+        // 5. try to read the operator's collateral directly on the avs
+        (address[] memory collaterals, uint256[] memory amounts) = middleware.getOperatorCollaterals(operator);
+        assertEq(collaterals.length, 1);
+        assertEq(amounts.length, 1);
+        assertEq(collaterals[0], address(mainnetCbEth));
+        assertEq(amounts[0], 99_999_999_999_999_999_999);
+
+        // 6. try to read the authorized signers
+        (IOperatorsRegistryV2.Operator memory opData, bool isActive, address[] memory authSigners) =
+            registry.getOperator(operator);
+        assertEq(authSigners.length, authorizedSigners.length);
+        assertEq(authSigners[0], authorizedSigner);
+
+        // 7. try to pause the authorized signer and check its status again
+        vm.prank(operator);
+        registry.pauseOperatorAuthorizedSigner(authorizedSigner);
+        (opData, isActive, authSigners) = registry.getOperator(operator);
+        // The authorized signer should be paused immediately and will not show up in the authorized signers list
+        assertEq(authSigners.length, 0);
+    }
+}

--- a/contracts/test/mainnet/SymbioticMiddlewareV1.t.sol
+++ b/contracts/test/mainnet/SymbioticMiddlewareV1.t.sol
@@ -22,7 +22,7 @@ import {Subnetwork} from "@symbiotic/core/contracts/libraries/Subnetwork.sol";
 
 import {IERC20} from "@openzeppelin-v4.9.0/contracts/interfaces/IERC20.sol";
 
-contract SymbioticMiddlewareMainnetTest is Test {
+contract SymbioticMiddlewareV1MainnetTest is Test {
     using Subnetwork for address;
 
     uint48 EPOCH_DURATION = 1 days;


### PR DESCRIPTION
Closes #40 

> [!IMPORTANT]
> WIP

Summary of the changes:

Added new logic to add a set of _authorized signers_ per operator.
This solves the problem of operators having to use their operator private key to run their bolt-sidecar: after this upgrade, operators will be able to specify additional EOAs that can make commitments on their behalf.

This will require an upgrade of all our contracts. Here's how the new flow will look like:

1. `registerOperator(rpcEndpoint, extraData, authorizedSigners)`: A set of authorized signers can be specified at registration time, along with the operator RPC and extradata.
2. operators can always update the set of authorized signers in the following ways:
    a. `addOperatorAuthorizedSigner(address signer)` allows an operator to add a signer to the authorized set
    b. `pauseOperatorAuthorizedSigner(address signer)` allows an operator to pause a signer. it will still be considered active until the end of the current epoch, and from the next epoch onward it will be considered paused or inactive
    c. `unpauseOperatorAuthorizedSigner(address signer)` self-explanatory, but will consider the signer active again after the end of the current epoch
    d. `removeOperatorAuthorizedSigner(address signer)` self-explanatory, but will remove the signer from the set if they are currently paused